### PR TITLE
Decrease docker image size - remove downloaded zip files

### DIFF
--- a/src/p4aspaces/environments/p4a-py2-api19-ndkbundle/Dockerfile
+++ b/src/p4aspaces/environments/p4a-py2-api19-ndkbundle/Dockerfile
@@ -16,13 +16,14 @@ RUN apt update && apt install -y zip python3 python-pip python python3-virtualen
 
 # Install Android SDK:
 RUN mkdir /sdk-install/
-RUN cd /sdk-install && wget https://dl.google.com/android/repository/${SDK_TOOLS}
-RUN cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager
+RUN cd /sdk-install && wget https://dl.google.com/android/repository/${SDK_TOOLS} \
+    && cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager \
+    && rm -v sdk-tools-*.zip
 RUN /sdk-install/tools/bin/sdkmanager --update
 RUN yes | /sdk-install/tools/bin/sdkmanager "platform-tools" "platforms;android-19" "ndk-bundle" "build-tools;25.0.2"
 
 # Obtain Android NDK:
-RUN mkdir -p /tmp/ndk/ && cd /tmp/ndk/ && wget ${NDK_DL} && unzip -q android-ndk*.zip && mv android-*/ /ndk/
+RUN mkdir -p /tmp/ndk/ && cd /tmp/ndk/ && wget ${NDK_DL} && unzip -q android-ndk*.zip && mv android-*/ /ndk/ && rm -v android-ndk*.zip
 
 # Install shared packages:
 {INSTALL_SHARED_PACKAGES}

--- a/src/p4aspaces/environments/p4a-py2-api28ndk21/Dockerfile
+++ b/src/p4aspaces/environments/p4a-py2-api28ndk21/Dockerfile
@@ -17,13 +17,14 @@ RUN apt update && apt install -y zip python3 python-pip python python3-virtualen
 
 # Install Android SDK:
 RUN mkdir /sdk-install/
-RUN cd /sdk-install && wget https://dl.google.com/android/repository/${SDK_TOOLS}
-RUN cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager
+RUN cd /sdk-install && wget https://dl.google.com/android/repository/${SDK_TOOLS} \
+&&  cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager \
+&&  rm -v sdk-tools-*.zip
 RUN /sdk-install/tools/bin/sdkmanager --update
 RUN yes | /sdk-install/tools/bin/sdkmanager "platform-tools" "platforms;android-28" "build-tools;28.0.3"
 
 # Obtain Android NDK:
-RUN mkdir -p /tmp/ndk/ && cd /tmp/ndk/ && wget ${NDK_DL} && unzip -q android-ndk*.zip && mv android-*/ /ndk/
+RUN mkdir -p /tmp/ndk/ && cd /tmp/ndk/ && wget ${NDK_DL} && unzip -q android-ndk*.zip && mv android-*/ /ndk/ && rm -v android-ndk*.zip
 
 # Install shared packages:
 {INSTALL_SHARED_PACKAGES}

--- a/src/p4aspaces/environments/p4a-py3-api28ndk19/Dockerfile
+++ b/src/p4aspaces/environments/p4a-py3-api28ndk19/Dockerfile
@@ -17,13 +17,14 @@ RUN apt update && apt install -y zip python3 python-pip python python3-venv pyth
 
 # Install Android SDK:
 RUN mkdir /sdk-install/
-RUN cd /sdk-install && wget https://dl.google.com/android/repository/${SDK_TOOLS}
-RUN cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager
+RUN cd /sdk-install && wget https://dl.google.com/android/repository/${SDK_TOOLS} \
+&&  cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager \
+&&  rm -v sdk-tools-*.zip
 RUN /sdk-install/tools/bin/sdkmanager --update
 RUN yes | /sdk-install/tools/bin/sdkmanager "platform-tools" "platforms;android-28" "build-tools;28.0.3"
 
 # Obtain Android NDK:
-RUN mkdir -p /tmp/ndk/ && cd /tmp/ndk/ && wget ${NDK_DL} && unzip -q android-ndk*.zip && mv android-*/ /ndk/
+RUN mkdir -p /tmp/ndk/ && cd /tmp/ndk/ && wget ${NDK_DL} && unzip -q android-ndk*.zip && mv android-*/ /ndk/ && rm -v android-ndk*.zip
 
 # Install shared packages:
 {INSTALL_SHARED_PACKAGES}

--- a/src/p4aspaces/environments/p4a-py3-api28ndk21/Dockerfile
+++ b/src/p4aspaces/environments/p4a-py3-api28ndk21/Dockerfile
@@ -17,13 +17,14 @@ RUN apt update && apt install -y zip python3 python-pip python python3-venv pyth
 
 # Install Android SDK:
 RUN mkdir /sdk-install/
-RUN cd /sdk-install && wget https://dl.google.com/android/repository/${SDK_TOOLS}
-RUN cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager
+RUN cd /sdk-install && wget https://dl.google.com/android/repository/${SDK_TOOLS} \
+&& cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager \
+&& rm -v sdk-tools-*.zip
 RUN /sdk-install/tools/bin/sdkmanager --update
 RUN yes | /sdk-install/tools/bin/sdkmanager "platform-tools" "platforms;android-28" "build-tools;28.0.3"
 
 # Obtain Android NDK:
-RUN mkdir -p /tmp/ndk/ && cd /tmp/ndk/ && wget ${NDK_DL} && unzip -q android-ndk*.zip && mv android-*/ /ndk/
+RUN mkdir -p /tmp/ndk/ && cd /tmp/ndk/ && wget ${NDK_DL} && unzip -q android-ndk*.zip && mv android-*/ /ndk/ && rm -v android-ndk*.zip
 
 # Install shared packages:
 {INSTALL_SHARED_PACKAGES}

--- a/src/p4aspaces/environments/p4a-py3crystax-api19-ndkbundle/Dockerfile
+++ b/src/p4aspaces/environments/p4a-py3crystax-api19-ndkbundle/Dockerfile
@@ -17,8 +17,9 @@ RUN apt update && apt install -y zip python3 python-pip python python3-venv pyth
 
 # Install Android SDK:
 RUN mkdir /sdk-install/
-RUN cd /sdk-install && wget --read-timeout=5 --tries=0 https://dl.google.com/android/repository/${SDK_TOOLS}
-RUN cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager
+RUN cd /sdk-install && wget --read-timeout=5 --tries=0 https://dl.google.com/android/repository/${SDK_TOOLS} \
+ && cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager \
+ && rm -v sdk-tools-*.zip
 RUN /sdk-install/tools/bin/sdkmanager --update
 RUN yes | /sdk-install/tools/bin/sdkmanager "platform-tools" "platforms;android-19" "ndk-bundle" "build-tools;25.0.2"
 

--- a/src/p4aspaces/environments/p4a-py3crystax-api26ndk19/Dockerfile
+++ b/src/p4aspaces/environments/p4a-py3crystax-api26ndk19/Dockerfile
@@ -17,8 +17,9 @@ RUN apt update && apt install -y zip python3 python-pip python python3-venv pyth
 
 # Install Android SDK:
 RUN mkdir /sdk-install/
-RUN cd /sdk-install && wget --read-timeout=5 --tries=0 https://dl.google.com/android/repository/${SDK_TOOLS}
-RUN cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager
+RUN cd /sdk-install && wget --read-timeout=5 --tries=0 https://dl.google.com/android/repository/${SDK_TOOLS} \
+&&  cd /sdk-install && unzip ./sdk-tools-*.zip && chmod +x ./tools//bin/sdkmanager \
+&&  rm -v sdk-tools-*.zip
 RUN /sdk-install/tools/bin/sdkmanager --update
 RUN yes | /sdk-install/tools/bin/sdkmanager "platform-tools" "platforms;android-$ANDROIDAPI" "ndk-bundle" "build-tools;26.0.1"
 


### PR DESCRIPTION
Decrease Docker image size: remove downloaded zip files.
As a result, the image is reduced by almost 900 mb

![Screenshot_20190313_143816](https://user-images.githubusercontent.com/37062532/54276259-f25eec80-459d-11e9-8ab1-e78f019fdd33.png)

[Image size in Registry1](https://quay.io/repository/homdx/flask-hello?tab=tags)

Image size in disk:
```
$docker images
REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
test3                         latest              cfeed172dc0f        6 seconds ago       5.75 GB
test2                         latest              b21afaef471a        About an hour ago   6.61 GB
```
[Image size in Registry2](https://hub.docker.com/r/homdx/flask-hello/tags)
![Screenshot_20190313_163330](https://user-images.githubusercontent.com/37062532/54282821-d5321a00-45ad-11e9-9392-e643e9f25da4.png)
